### PR TITLE
Automatically detect module path

### DIFF
--- a/Retire-CMApplication.ps1
+++ b/Retire-CMApplication.ps1
@@ -6,7 +6,7 @@ function Retire-CMApplication {
     )
 
     # import cm module
-    Import-Module 'C:\Program Files (x86)\Microsoft Configuration Manager\AdminConsole\bin\ConfigurationManager.psd1'
+    Import-Module ($Env:SMS_ADMIN_UI_PATH.Substring(0,$Env:SMS_ADMIN_UI_PATH.Length-5) + '\ConfigurationManager.psd1')
 
     # change to the cm site drive
     $PSD = Get-PSDrive -PSProvider CMSite


### PR DESCRIPTION
Module patch is hardcoded in the original script, this automatically uses $Env:SMS_ADMIN_UI_PATH variable to find it wherever it may be installed