### PR TITLE
Automatically detect module path

### DIFF
--- a/SCCM/Retire-CMApplication.ps1
+++ b/SCCM/Retire-CMApplication.ps1
@@ -6,7 +6,7 @@ function Retire-CMApplication {
     )
 
     # import cm module
-    Import-Module '\\sccm01\SMS_Company\AdminConsole\bin\ConfigurationManager.psd1'
+    Import-Module ($Env:SMS_ADMIN_UI_PATH.Substring(0,$Env:SMS_ADMIN_UI_PATH.Length-5) + '\ConfigurationManager.psd1')
 
     # change to the cm site drive
     $PSD = Get-PSDrive -PSProvider CMSite

--- a/SCCM/Retire-CMApplicationGUI.ps1
+++ b/SCCM/Retire-CMApplicationGUI.ps1
@@ -140,7 +140,7 @@ function Create-UtilityForm {
 
 try {
     # make sure we have access to CM commands before we continue
-    Import-Module 'E:\SCCM\AdminConsole\bin\ConfigurationManager.psd1'
+    Import-Module ($Env:SMS_ADMIN_UI_PATH.Substring(0,$Env:SMS_ADMIN_UI_PATH.Length-5) + '\ConfigurationManager.psd1')
     Set-Location -Path "$(Get-PSDrive -PSProvider CMSite):\" -ErrorAction Stop
     Create-UtilityForm
 } catch {


### PR DESCRIPTION
Module patch is hardcoded in the original script, this automatically uses $Env:SMS_ADMIN_UI_PATH variable to find it wherever it may be installed